### PR TITLE
Fix the spelling of "Entertainment"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ jobs:
         set -e
         sudo xcode-select --switch /Applications/Xcode_10.2.1.app/Contents/Developer
         brew update
-        HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/Human-Entertainmnet/homebrew-tap"
+        HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/Human-Entertainment/homebrew-tap"
         mkdir -p "$HOMEBREW_TAP_DIR"
         rm -rf "$HOMEBREW_TAP_DIR"
         ln -s "$PWD" "$HOMEBREW_TAP_DIR"


### PR DESCRIPTION
Fix the spelling of "Entertainment" in `azure-pipelines.yml` on line 10